### PR TITLE
Vbox bridgeadapter arg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,3 +62,27 @@ Zcash
 A non-mining Zcash full node is included as part of this deployment.
 This allows for processing of Zcash shielded transactions.
 The Zcash deployment is primarily configured using ``zcashnode`` in ``s4.nix``.
+
+Tor
+---
+
+A Tor daemon is included as part of this deployment.
+This allows the service website and Tahoe-LAFS daemons to operate as Onion services.
+This, in turn, provides location privacy for users browsing the website and operating Tahoe-LAFS clients.
+The Tor node is primary configured using ``zcashnode`` in ``s4.nix``
+(but maybe this should change).
+
+Tor Service Keys
+````````````````
+
+To publish the website at a stable Onion service address,
+the deployment requires use of persistent private keys.
+No such keys have yet been provisioned.
+Meanwhile, you can generate some throw-away keys::
+
+  pip install stem
+  mkdir -p ops/secrets/onion-services/v3
+  cd ops/secrets/onion-services/v3
+  bin/generate-onion-keys
+
+You must have keys before you can use ``nixops`` to deploy the service.

--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,19 @@ Creating a deployment running entirely within local VirtualBox VMs is an easy wa
 At least, it is in principle.
 In practice, the interaction between NixOps and VirtualBox seems fragile.
 There is a good chance this won't actually work for you.
-It doesn't work for me.
 Bearing that in mind ...
 
 With a working directory of the root of a checkout of S4-2.0::
 
    nixops create --deployment your-s4-petname ops/s4.nix ops/s4-vbox.nix
+   nixops set-args --arg bridgeAdapter '"<host network interface>"'
    nixops deploy --deployment your-s4-petname
+
+For ``<host network interface>``,
+select a network interface on the host which can route traffic out of your network
+and which has a DHCP server.
+This might be something like ``wlp4s0`` or ``enp0s31f6``.
+Make sure to include all of the quotes as indicated above.
 
 AWS Deployment
 --------------

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,6 @@ Meanwhile, you can generate some throw-away keys::
   pip install stem
   mkdir -p ops/secrets/onion-services/v3
   cd ops/secrets/onion-services/v3
-  bin/generate-onion-keys
+  ../../../../bin/generate-onion-keys
 
 You must have keys before you can use ``nixops`` to deploy the service.

--- a/bin/generate-onion-keys
+++ b/bin/generate-onion-keys
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from stem.control import Controller
+from binascii import a2b_base64
 
 def main():
     c = Controller.from_port()
@@ -14,10 +15,10 @@ def main():
         hostname.write(
             response.service_id + ".onion\n"
         )
-    with open("signup-website.secret", "w") as secret:
+    with open("signup-website.secret", "wb") as secret:
         secret.write(
-            "== ed25519v1-secret: type0 ==\x00\x00\x00" +
-            response.private_key.decode("base64")
+            b"== ed25519v1-secret: type0 ==\x00\x00\x00" +
+            a2b_base64(response.private_key)
         )
 
 main()

--- a/bin/generate-onion-keys
+++ b/bin/generate-onion-keys
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from stem.control import Controller
+
+def main():
+    c = Controller.from_port()
+    c.authenticate()
+    response = c.create_ephemeral_hidden_service(
+        80,
+        key_type="NEW",
+        key_content="ED25519-V3",
+    )
+    with open("signup-website.hostname", "w") as hostname:
+        hostname.write(
+            response.service_id + ".onion\n"
+        )
+    with open("signup-website.secret", "w") as secret:
+        secret.write(
+            "== ed25519v1-secret: type0 ==\x00\x00\x00" +
+            response.private_key.decode("base64")
+        )
+
+main()

--- a/ops/s4-ec2.nix
+++ b/ops/s4-ec2.nix
@@ -12,7 +12,7 @@ let
     deployment.ec2.region = region;
     # We need at least 2GB for the Zcash bootstrap process alone.
     deployment.ec2.ebsInitialRootDiskSize = 10;
-    deployment.ec2.instanceType = "t3.small";
+    deployment.ec2.instanceType = "t3.medium";
     deployment.ec2.keyPair = resources.ec2KeyPairs.my-key-pair;
     deployment.ec2.securityGroups = [ "allow_all" ];
   };

--- a/ops/s4-vbox.nix
+++ b/ops/s4-vbox.nix
@@ -1,10 +1,12 @@
-{
-  zcashnode =
+{ bridgeAdapter }:
+{ zcashnode =
     { config, pkgs, ... }:
     { deployment.targetEnv = "virtualbox";
       deployment.virtualbox.memorySize = 8192; # megabytes
       deployment.virtualbox.vcpu = 1; # number of cpus
       deployment.virtualbox.headless = true;
-      deployment.virtualbox.vmFlags = ["--nic1" "bridged"];
+      deployment.virtualbox.vmFlags =
+      [ "--nic1" "bridged" "--bridgeadapter1" bridgeAdapter
+      ];
     };
 }

--- a/ops/s4-vbox.nix
+++ b/ops/s4-vbox.nix
@@ -5,5 +5,6 @@
       deployment.virtualbox.memorySize = 8192; # megabytes
       deployment.virtualbox.vcpu = 1; # number of cpus
       deployment.virtualbox.headless = true;
+      deployment.virtualbox.vmFlags = ["--nic1" "bridged"];
     };
 }

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -67,5 +67,11 @@
         ExecStart               = "${zcash}/bin/zcashd -conf=${conf}";
       };
     };
+
+    services.tor.enable = true;
+    /*
+     * We don't make outgoing Tor connections via the SOCKS proxy.
+     */
+    services.tor.client.socksPolicy = "reject *";
   };
 }

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -143,8 +143,8 @@
 
     # Construct a directory with a suitable structure for consumption by Tor
     # as an Onion service configuration directory.  We can only use Nix's
-    # deployment.keys feature to create create a flat hierarchy in /run/keys
-    # so we need systemd's help to create the structure required by Tor.
+    # deployment.keys feature to create a flat hierarchy in /run/keys so we
+    # need systemd's help to create the structure required by Tor.
     #
     # https://nixos.org/nixos/manual/options.html#opt-systemd.tmpfiles.rules
     systemd.tmpfiles.rules =

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -196,8 +196,10 @@
       wantedBy    = [ "multi-user.target" ];
 
       # Make sure Tor is up and our keys are available.
+      # https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=
+      requires = [ "tor.service" "signup-website-tor-onion-service.secret-key.service" ];
+      # https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
       after = [ "tor.service" "signup-website-tor-onion-service.secret-key.service" ];
-      wants = [ "tor.service" "signup-website-tor-onion-service.secret-key.service" ];
 
       script = ''
       twist --log-format=text web \

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -1,9 +1,14 @@
 # Describe the software to run on the infrastructure described by s4-ec2.nix.
 {
   network.description = "Zcash server";
+
   zcashnode =
-  { config, pkgs, ... }:
+  { lib, pkgs, ... }:
   let zcash = pkgs.callPackage ./zcash/default.nix { };
+      s4signupwebsite = pkgs.callPackage ./s4signupwebsite.nix { };
+      torControlPort = 9051;
+      websiteOnion2Dir = "/run/onion/v2/signup-website";
+      websiteOnion3Dir = "/run/onion/v3/signup-website";
   in
   # Allow the two Zcash protocol ports.
   { networking.firewall.allowedTCPPorts = [ 18232 18233 ];
@@ -13,6 +18,24 @@
       home = "/var/lib/zcashd";
       description = "Runs a full Zcash node";
     };
+
+    /*
+     * Nix-generated Tor configuration file has a `User tor` that we cannot
+     * easily control.  This option sets the UID *and* GID of the Tor process.
+     * The keys we want to pass to Tor for the website configuration are in
+     * /run/keys which is group-readable and group-owned by `keys`.  So, get
+     * the tor user's primary group to be the keys group so it can actually
+     * read the keys.
+     *
+     * We have to force this value to override the previously supplied value.
+     *
+     * Note that this means the tor user no longer belongs to the tor group.
+     * This may break something but if it does I haven't yet observed it.
+     *
+     * This is kind of lame, I think.  Maybe it would be better not to have
+     * keys on the disk or something?
+     */
+    users.users.tor.group = lib.mkForce "keys";
 
     environment.systemPackages = [
       zcash
@@ -68,10 +91,109 @@
       };
     };
 
+    /*
+     * Run a Tor node so we can operate a hidden service to allow user signup.
+     */
     services.tor.enable = true;
     /*
      * We don't make outgoing Tor connections via the SOCKS proxy.
      */
     services.tor.client.socksPolicy = "reject *";
+
+    /*
+     * Enable the control port so that we can do interesting things with the
+     * daemon from other programs.
+     */
+    services.tor.controlPort = torControlPort;
+
+    services.tor.extraConfig = ''
+      # Enable authentication on the ControlPort via a secret shared cookie.
+      CookieAuthentication 1
+    '';
+
+    /*
+     * Customize the Tor service so that it is able to read the keys with which
+     * we will supply it.
+     */
+    systemd.services.tor =
+    { serviceConfig =
+      { ReadWritePaths =
+        [ "/var/lib/tor"
+        ];
+      };
+    };
+
+    /* Provide a private key for the website Onion service. */
+    /* https://elvishjerricco.github.io/2018/06/24/secure-declarative-key-management.html */
+    /* https://nixos.org/nixops/manual/#idm140737318276736 */
+    deployment.keys."signup-website-tor-onion-service-v3.secret" =
+    { keyFile = ./secrets/onion-services/v3/signup-website.secret;
+      user = "tor";
+      group = "tor";
+      permissions = "0600";
+    };
+    deployment.keys."signup-website-tor-onion-service-v3.public" =
+    { keyFile = ./secrets/onion-services/v3/signup-website.public;
+      user = "tor";
+      group = "tor";
+      permissions = "0600";
+    };
+    deployment.keys."signup-website-tor-onion-service-v3.hostname" =
+    { keyFile = ./secrets/onion-services/v3/hostname;
+      user = "tor";
+      group = "tor";
+      permissions = "0600";
+    };
+
+    deployment.keys."signup-website-tor-onion-service-v2.private_key" =
+    { keyFile = ./secrets/onion-services/v2/signup-website.private_key;
+      user = "tor";
+      group = "tor";
+      permissions = "0600";
+    };
+    deployment.keys."signup-website-tor-onion-service-v2.hostname" =
+    { keyFile = ./secrets/onion-services/v2/hostname;
+      user = "tor";
+      group = "tor";
+      permissions = "0600";
+    };
+
+    # https://nixos.org/nixos/manual/options.html#opt-systemd.tmpfiles.rules
+    systemd.tmpfiles.rules =
+    [ "d  ${websiteOnion3Dir}                       0700 tor tor - -"
+      "L+ ${websiteOnion3Dir}/hs_ed25519_secret_key -    -   -   - /run/keys/signup-website-tor-onion-service-v3.secret"
+      "L+ ${websiteOnion3Dir}/hs_ed25519_public_key -    -   -   - /run/keys/signup-website-tor-onion-service-v3.public"
+      "L+ ${websiteOnion3Dir}/hostname              -    -   -   - /run/keys/signup-website-tor-onion-service-v3.hostname"
+
+      "d  /run/onion                                0700 tor tor - -"
+      "d  /run/onion/v2                             0700 tor tor - -"
+      "d  ${websiteOnion2Dir}                       0700 tor tor - -"
+      "L+ ${websiteOnion2Dir}/private_key           -    -   -   - /run/keys/signup-website-tor-onion-service-v2.private_key"
+      "L+ ${websiteOnion2Dir}/hostname              -    -   -   - /run/keys/signup-website-tor-onion-service-v2.hostname"
+    ];
+
+    /*
+     * Operate a static website allowing user signup, exposed via the Tor
+     * hidden service.
+     */
+    systemd.services."signup-website" =
+    { unitConfig.Documentation = "https://leastauthority.com/";
+      description = "The S4 2.0 signup website.";
+
+      path = [ (pkgs.python27.withPackages (ps: [ ps.twisted ps.txtorcon ])) ];
+
+      # Get it to start as a part of the normal boot process.
+      wantedBy    = [ "multi-user.target" ];
+
+      # Make sure Tor is up and our keys are available.
+      after = [ "tor.service" "signup-website-tor-onion-service.secret-key.service" ];
+      wants = [ "tor.service" "signup-website-tor-onion-service.secret-key.service" ];
+
+      script = ''
+      twist --log-format=text web \
+        --path ${s4signupwebsite} \
+        --port onion:version=3:public_port=80:controlPort=${toString torControlPort}:hiddenServiceDir=${websiteOnion3Dir}
+      '';
+  };
   };
 }

--- a/ops/s4.nix
+++ b/ops/s4.nix
@@ -145,6 +145,11 @@
       permissions = "0600";
     };
 
+    /*
+     * Also provide a v2 key for a v2 version of the service.  v3 is
+     * supposedly better so we may never use this and it might just be deleted
+     * later.
+     */
     deployment.keys."signup-website-tor-onion-service-v2.private_key" =
     { keyFile = ./secrets/onion-services/v2/signup-website.private_key;
       user = "tor";
@@ -158,6 +163,11 @@
       permissions = "0600";
     };
 
+    # Construct a directory with a suitable structure for consumption by Tor
+    # as an Onion service configuration directory.  We can only use Nix's
+    # deployment.keys feature to create create a flat hierarchy in /run/keys
+    # so we need systemd's help to create the structure required by Tor.
+    #
     # https://nixos.org/nixos/manual/options.html#opt-systemd.tmpfiles.rules
     systemd.tmpfiles.rules =
     [ "d  ${websiteOnion3Dir}                       0700 tor tor - -"

--- a/ops/s4signupwebsite.nix
+++ b/ops/s4signupwebsite.nix
@@ -1,0 +1,1 @@
+{ config, pkgs, ... }: ../signup-website

--- a/signup-website/index.html
+++ b/signup-website/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    Sign up for S4.
+  </body>
+</html>


### PR DESCRIPTION
This allows the user to specify a network interface for the VBox bridge on the command line.

This is necessary to make this work on my laptop where VBox otherwise picks a non-working interface and no traffic can be routed from the host to the VM.