### PR TITLE
Accept a bridge interface as an argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,13 +13,19 @@ Creating a deployment running entirely within local VirtualBox VMs is an easy wa
 At least, it is in principle.
 In practice, the interaction between NixOps and VirtualBox seems fragile.
 There is a good chance this won't actually work for you.
-It doesn't work for me.
 Bearing that in mind ...
 
 With a working directory of the root of a checkout of S4-2.0::
 
    nixops create --deployment your-s4-petname ops/s4.nix ops/s4-vbox.nix
+   nixops set-args --arg bridgeAdapter '"<host network interface>"'
    nixops deploy --deployment your-s4-petname
+
+For ``<host network interface>``,
+select a network interface on the host which can route traffic out of your network
+and which has a DHCP server.
+This might be something like ``wlp4s0`` or ``enp0s31f6``.
+Make sure to include all of the quotes as indicated above.
 
 AWS Deployment
 --------------

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ With a working directory of the root of a checkout of S4-2.0::
 
    nixops create --deployment your-s4-petname ops/s4.nix ops/s4-vbox.nix
    nixops set-args --arg bridgeAdapter '"<host network interface>"'
-   nixops deploy --deployment your-s4-petname
+   nixops deploy --force-reboot --deployment your-s4-petname
 
 For ``<host network interface>``,
 select a network interface on the host which can route traffic out of your network

--- a/ops/s4-vbox.nix
+++ b/ops/s4-vbox.nix
@@ -1,10 +1,12 @@
-{
-  zcashnode =
+{ bridgeAdapter }:
+{ zcashnode =
     { config, pkgs, ... }:
     { deployment.targetEnv = "virtualbox";
       deployment.virtualbox.memorySize = 8192; # megabytes
       deployment.virtualbox.vcpu = 1; # number of cpus
       deployment.virtualbox.headless = true;
-      deployment.virtualbox.vmFlags = ["--nic1" "bridged"];
+      deployment.virtualbox.vmFlags =
+      [ "--nic1" "bridged" "--bridgeadapter1" bridgeAdapter
+      ];
     };
 }


### PR DESCRIPTION
This allows the user to specify a network interface for the VBox bridge on the command line.

This is necessary to make this work on my laptop where VBox otherwise picks a non-working interface and no traffic can be routed from the host to the VM.